### PR TITLE
Add VaultHolder class for detection from other plugins

### DIFF
--- a/src/main/java/com/drtshock/playervaults/util/Serialization.java
+++ b/src/main/java/com/drtshock/playervaults/util/Serialization.java
@@ -73,7 +73,9 @@ public class Serialization {
     }
 
     public static Inventory toInventory(List<String> stringItems, int number, boolean large) {
-        Inventory inv = Bukkit.createInventory(null, (large) ? 54 : 27, ChatColor.RED + "Vault #" + number);
+        VaultHolder holder = new VaultHolder(number);
+        Inventory inv = Bukkit.createInventory(holder, (large) ? 54 : 27, ChatColor.RED + "Vault #" + number);
+        holder.setInventory(inv);
         List<ItemStack> contents = new ArrayList<ItemStack>();
         for(String piece:stringItems) {
             if (piece.equalsIgnoreCase("null")) {

--- a/src/main/java/com/drtshock/playervaults/util/VaultHolder.java
+++ b/src/main/java/com/drtshock/playervaults/util/VaultHolder.java
@@ -1,0 +1,47 @@
+package com.drtshock.playervaults.util;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+/**
+ * Represents a VaultHolder to assist in detection of Player Vaults from
+ * other plugins.
+ */
+public class VaultHolder implements InventoryHolder{
+
+	private Inventory inventory;
+	private int vaultNumber = 0;
+
+	/**
+	 * Creates a new vault holder
+	 * 
+	 * @param vaultNumber the vault number this holder is using
+	 */
+	public VaultHolder(int vaultNumber){
+		this.vaultNumber = vaultNumber;
+	}
+
+	/**
+	 * Gets the vault number this holder is currently using
+	 * 
+	 * @return the vault number
+	 */
+	public int getVaultNumber(){
+		return vaultNumber;
+	}
+
+	/**
+	 * Sets the inventory this vault holder holds
+	 * 
+	 * @param inventory the inventory, may be null
+	 */
+	public void setInventory(Inventory inventory){
+		this.inventory = inventory;
+	}
+
+	@Override
+	public Inventory getInventory(){
+		return inventory;
+	}
+
+}

--- a/src/main/java/com/drtshock/playervaults/util/VaultManager.java
+++ b/src/main/java/com/drtshock/playervaults/util/VaultManager.java
@@ -68,7 +68,9 @@ public class VaultManager {
         } else {
             YamlConfiguration playerFile = getPlayerVaultFile(holder);
             if (playerFile.getConfigurationSection("vault" + number) == null) {
-                inv = Bukkit.createInventory(null, 54, ChatColor.DARK_RED + "Vault #" + String.valueOf(number));
+                VaultHolder vaultHolder = new VaultHolder(number);
+                inv = Bukkit.createInventory(vaultHolder, 54, ChatColor.DARK_RED + "Vault #" + String.valueOf(number));
+                vaultHolder.setInventory(inv);
             } else {
                 List<String> data = new ArrayList<String>();
                 for(int x = 0; x < ((large) ? 54 : 27); x++) {
@@ -96,7 +98,9 @@ public class VaultManager {
         YamlConfiguration playerFile = getPlayerVaultFile(holder);
         List<String> data = playerFile.getStringList("vault" + number);
         if (data == null) {
-            Inventory inv = Bukkit.createInventory(null, 54, ChatColor.GREEN + "Vault #" + String.valueOf(number));
+            VaultHolder vaultHolder = new VaultHolder(number);
+            Inventory inv = Bukkit.createInventory(vaultHolder, 54, ChatColor.GREEN + "Vault #" + String.valueOf(number));
+            vaultHolder.setInventory(inv);
             return inv;
         } else {
             Inventory inv = Serialization.toInventory(data, number, true);


### PR DESCRIPTION
Prior to this commit plugins could not (easily) detect if an inventory a
player is using is a Player Vault inventory. This commit changes that by
assigning a "VaultHolder" to an inventory when it is created.

This new holder allows for plugins to easily detect if the inventory is
a player vault due to the new VaultHolder class.

The VaultHolder also holds information such as the vault number. The
vault number is required for further handling of the vault.

Without this addition plugins, such as AntiShare, cannot correctly
handle a vault.
