### PR TITLE
Removed Storing of open inventories.

### DIFF
--- a/src/main/java/com/drtshock/playervaults/PlayerVaults.java
+++ b/src/main/java/com/drtshock/playervaults/PlayerVaults.java
@@ -45,7 +45,6 @@ public class PlayerVaults extends JavaPlugin {
     private String link = "";
     private HashMap<String, SignSetInfo> setSign = new HashMap<>();
     private HashMap<String, VaultViewInfo> inVault = new HashMap<>();
-    private HashMap<String, Inventory> openInventories = new HashMap<>();
     private Economy economy = null;
     private boolean dropOnDeath = false;
     private boolean useVault = false;
@@ -111,7 +110,7 @@ public class PlayerVaults extends JavaPlugin {
                         // ignore
                     }
 
-                    this.openInventories.remove(info.toString());
+
                 }
 
                 this.inVault.remove(player.getName());
@@ -312,10 +311,6 @@ public class PlayerVaults extends JavaPlugin {
 
     public HashMap<String, VaultViewInfo> getInVault() {
         return this.inVault;
-    }
-
-    public HashMap<String, Inventory> getOpenInventories() {
-        return this.openInventories;
     }
 
     public boolean needsUpdate() {

--- a/src/main/java/com/drtshock/playervaults/listeners/Listeners.java
+++ b/src/main/java/com/drtshock/playervaults/listeners/Listeners.java
@@ -59,8 +59,6 @@ public class Listeners implements Listener {
                 } catch (IOException e) {
                     // ignore
                 }
-
-                PlayerVaults.getInstance().getOpenInventories().remove(info.toString());
             }
             PlayerVaults.getInstance().getInVault().remove(player.getName());
         }

--- a/src/main/java/com/drtshock/playervaults/vaultmanagement/UUIDVaultManager.java
+++ b/src/main/java/com/drtshock/playervaults/vaultmanagement/UUIDVaultManager.java
@@ -71,27 +71,22 @@ public class UUIDVaultManager {
 
         VaultViewInfo info = new VaultViewInfo(player.getUniqueId().toString(), number);
         Inventory inv;
-        if (PlayerVaults.getInstance().getOpenInventories().containsKey(info.toString())) {
-            inv = PlayerVaults.getInstance().getOpenInventories().get(info.toString());
-        } else {
-            YamlConfiguration playerFile = getPlayerVaultFile(player.getUniqueId());
-            if (playerFile.getConfigurationSection("vault" + number) == null) {
-                VaultHolder vaultHolder = new VaultHolder(number);
-                if (EconomyOperations.payToCreate(player)) {
-                    inv = Bukkit.createInventory(vaultHolder, size, Lang.VAULT_TITLE.toString().replace("%number", String.valueOf(number)).replace("%p", player.getName()));
-                    vaultHolder.setInventory(inv);
-                } else {
-                    player.sendMessage(Lang.TITLE.toString() + Lang.INSUFFICIENT_FUNDS.toString());
-                    return null;
-                }
+        YamlConfiguration playerFile = getPlayerVaultFile(player.getUniqueId());
+        if (playerFile.getConfigurationSection("vault" + number) == null) {
+            VaultHolder vaultHolder = new VaultHolder(number);
+            if (EconomyOperations.payToCreate(player)) {
+                inv = Bukkit.createInventory(vaultHolder, size, Lang.VAULT_TITLE.toString().replace("%number", String.valueOf(number)).replace("%p", player.getName()));
+                vaultHolder.setInventory(inv);
             } else {
-                if (getInventory(playerFile, size, number) == null) {
-                    return null;
-                } else {
-                    inv = getInventory(playerFile, size, number);
-                }
+                player.sendMessage(Lang.TITLE.toString() + Lang.INSUFFICIENT_FUNDS.toString());
+                return null;
             }
-            PlayerVaults.getInstance().getOpenInventories().put(info.toString(), inv);
+        } else {
+            if (getInventory(playerFile, size, number) == null) {
+                return null;
+            } else {
+                inv = getInventory(playerFile, size, number);
+            }
         }
 
         return inv;
@@ -109,20 +104,15 @@ public class UUIDVaultManager {
         }
         VaultViewInfo info = new VaultViewInfo(holder.toString(), number);
         Inventory inv;
-        if (PlayerVaults.getInstance().getOpenInventories().containsKey(info.toString())) {
-            inv = PlayerVaults.getInstance().getOpenInventories().get(info.toString());
+        YamlConfiguration playerFile = getPlayerVaultFile(holder);
+        if (playerFile.getConfigurationSection("vault" + number) == null) {
+            return null;
         } else {
-            YamlConfiguration playerFile = getPlayerVaultFile(holder);
-            if (playerFile.getConfigurationSection("vault" + number) == null) {
+            if (getInventory(playerFile, size, number) == null) {
                 return null;
             } else {
-                if (getInventory(playerFile, size, number) == null) {
-                    return null;
-                } else {
-                    inv = getInventory(playerFile, size, number);
-                }
+                inv = getInventory(playerFile, size, number);
             }
-            PlayerVaults.getInstance().getOpenInventories().put(info.toString(), inv);
         }
         return inv;
     }
@@ -203,8 +193,6 @@ public class UUIDVaultManager {
         } else {
             sender.sendMessage(Lang.TITLE.toString() + Lang.DELETE_OTHER_VAULT.toString().replace("%v", String.valueOf(number)).replaceAll("%p", player.getName()));
         }
-
-        PlayerVaults.getInstance().getOpenInventories().remove(new VaultViewInfo(holder.toString(), number).toString());
     }
 
     /**

--- a/src/main/java/com/drtshock/playervaults/vaultmanagement/VaultManager.java
+++ b/src/main/java/com/drtshock/playervaults/vaultmanagement/VaultManager.java
@@ -87,31 +87,26 @@ public class VaultManager {
         }
         VaultViewInfo info = new VaultViewInfo(holder, number);
         Inventory inv;
-        if (PlayerVaults.getInstance().getOpenInventories().containsKey(info.toString())) {
-            inv = PlayerVaults.getInstance().getOpenInventories().get(info.toString());
-        } else {
-            YamlConfiguration playerFile = getPlayerVaultFile(holder);
-            if (playerFile.getConfigurationSection("vault" + number) == null) {
-                VaultHolder vaultHolder = new VaultHolder(number);
-                Player player = Bukkit.getPlayer(holder);
-                if (player == null) {
-                    return null;
-                }
-                if (EconomyOperations.payToCreate(player)) {
-                    inv = Bukkit.createInventory(vaultHolder, size, Lang.VAULT_TITLE.toString().replace("%number", String.valueOf(number)).replace("%p", holder));
-                    vaultHolder.setInventory(inv);
-                } else {
-                    player.sendMessage(Lang.TITLE.toString() + Lang.INSUFFICIENT_FUNDS.toString());
-                    return null;
-                }
-            } else {
-                if (getInventory(playerFile, size, number) == null) {
-                    return null;
-                } else {
-                    inv = getInventory(playerFile, size, number);
-                }
+        YamlConfiguration playerFile = getPlayerVaultFile(holder);
+        if (playerFile.getConfigurationSection("vault" + number) == null) {
+            VaultHolder vaultHolder = new VaultHolder(number);
+            Player player = Bukkit.getPlayer(holder);
+            if (player == null) {
+                return null;
             }
-            PlayerVaults.getInstance().getOpenInventories().put(info.toString(), inv);
+            if (EconomyOperations.payToCreate(player)) {
+                inv = Bukkit.createInventory(vaultHolder, size, Lang.VAULT_TITLE.toString().replace("%number", String.valueOf(number)).replace("%p", holder));
+                vaultHolder.setInventory(inv);
+            } else {
+                player.sendMessage(Lang.TITLE.toString() + Lang.INSUFFICIENT_FUNDS.toString());
+                return null;
+            }
+        } else {
+            if (getInventory(playerFile, size, number) == null) {
+                return null;
+            } else {
+                inv = getInventory(playerFile, size, number);
+            }
         }
         return inv;
     }
@@ -129,20 +124,15 @@ public class VaultManager {
         }
         VaultViewInfo info = new VaultViewInfo(holder, number);
         Inventory inv;
-        if (PlayerVaults.getInstance().getOpenInventories().containsKey(info.toString())) {
-            inv = PlayerVaults.getInstance().getOpenInventories().get(info.toString());
+        YamlConfiguration playerFile = getPlayerVaultFile(holder);
+        if (playerFile.getConfigurationSection("vault" + number) == null) {
+            return null;
         } else {
-            YamlConfiguration playerFile = getPlayerVaultFile(holder);
-            if (playerFile.getConfigurationSection("vault" + number) == null) {
+            if (getInventory(playerFile, size, number) == null) {
                 return null;
             } else {
-                if (getInventory(playerFile, size, number) == null) {
-                    return null;
-                } else {
-                    inv = getInventory(playerFile, size, number);
-                }
+                inv = getInventory(playerFile, size, number);
             }
-            PlayerVaults.getInstance().getOpenInventories().put(info.toString(), inv);
         }
         return inv;
     }


### PR DESCRIPTION
Allows for inventory size to change when a vault is already opened, Storing the inventory size was stopping it from upgrading vaults. Now server owners can use this plugin to allow donors to upgrade their vaults without restarting the server, or deleting their vault and remaking it.