### PR TITLE
Add CachedVaults

### DIFF
--- a/src/main/java/com/drtshock/playervaults/PlayerVaults.java
+++ b/src/main/java/com/drtshock/playervaults/PlayerVaults.java
@@ -99,6 +99,11 @@ public class PlayerVaults extends JavaPlugin {
     @Override
     public void onDisable() {
         for (Player player : Bukkit.getOnlinePlayers()) {
+            // Compilex Start - Flush all cached vaults and delete.
+            UUIDVaultManager.getInstance().getCachedVaults().flushVaultCacheToFile(player.getUniqueId());
+            UUIDVaultManager.getInstance().getCachedVaults().deleteVaultCache(player.getUniqueId());
+            // Compilex End
+            
             if (this.inVault.containsKey(player.getName())) {
                 Inventory inventory = player.getOpenInventory().getTopInventory();
                 if (inventory.getViewers().size() == 1) {
@@ -117,6 +122,7 @@ public class PlayerVaults extends JavaPlugin {
 
             player.closeInventory();
         }
+        
         saveSignsFile();
     }
 

--- a/src/main/java/com/drtshock/playervaults/commands/VaultCommand.java
+++ b/src/main/java/com/drtshock/playervaults/commands/VaultCommand.java
@@ -34,7 +34,7 @@ public class VaultCommand implements CommandExecutor {
                     if (VaultOperations.openOwnVault(player, args[0], true)) {
                         PlayerVaults.getInstance().getInVault().put(player.getUniqueId().toString(), new VaultViewInfo(player.getUniqueId(), Integer.parseInt(args[0])));
                     } else if (sender.hasPermission("playervaults.admin")) {
-                        OfflinePlayer searchPlayer = Bukkit.getOfflinePlayer(args[0]);
+                        OfflinePlayer searchPlayer = Bukkit.getOfflinePlayerSync(args[0]);
                         if (searchPlayer == null || !searchPlayer.hasPlayedBefore()) {
                             sender.sendMessage(Lang.TITLE.toString() + Lang.NO_PLAYER_FOUND.toString().replaceAll("%p", args[0]));
                             break;
@@ -54,7 +54,7 @@ public class VaultCommand implements CommandExecutor {
                     }
                     break;
                 case 2:
-                    OfflinePlayer searchPlayer = Bukkit.getOfflinePlayer(args[0]);
+                    OfflinePlayer searchPlayer = Bukkit.getOfflinePlayerSync(args[0]);
                     if (searchPlayer == null || !searchPlayer.hasPlayedBefore()) {
                         sender.sendMessage(Lang.TITLE.toString() + Lang.NO_PLAYER_FOUND.toString().replaceAll("%p", args[0]));
                         break;

--- a/src/main/java/com/drtshock/playervaults/vaultmanagement/CachedVaults.java
+++ b/src/main/java/com/drtshock/playervaults/vaultmanagement/CachedVaults.java
@@ -1,0 +1,48 @@
+package com.drtshock.playervaults.vaultmanagement;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.UUID;
+
+import org.bukkit.inventory.Inventory;
+
+@SuppressWarnings("serial")
+public class CachedVaults extends HashMap<UUID, CachedVaultsMap> {
+    public void setCachedVault(UUID playerUUID, int id, Inventory inventory){
+        CachedVaultsMap vaultCacheMap = this.containsKey(playerUUID) ? this.get(playerUUID) : new CachedVaultsMap();
+        vaultCacheMap.setCachedVault(id, inventory);
+        this.put(playerUUID, vaultCacheMap);
+    }
+    
+    public Inventory getCachedVault(UUID playerUUID, int id){
+        return this.containsKey(playerUUID) ? this.get(playerUUID).getCachedVault(id) : null;
+    }
+    
+    public boolean hasVaultCached(UUID playerUUID, int id){
+        return this.containsKey(playerUUID) && this.get(playerUUID).getCachedVault(id) != null;
+    }
+    
+    public void clearVaultCache(UUID playerUUID){
+        if(this.containsKey(playerUUID)){
+            this.get(playerUUID).clear();
+        }
+    }
+    
+    public void deleteVaultCache(UUID playerUUID){
+        this.remove(playerUUID);
+    }
+    
+    public void flushVaultCacheToFile(UUID playerUUID){
+        if(this.containsKey(playerUUID)){
+            for(java.util.Map.Entry<Integer, Inventory> data : this.get(playerUUID).entrySet()){
+                try {
+                    UUIDVaultManager.getInstance().saveVault(data.getValue(), playerUUID, data.getKey());
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            
+            this.deleteVaultCache(playerUUID);
+        }
+    }
+}

--- a/src/main/java/com/drtshock/playervaults/vaultmanagement/CachedVaultsMap.java
+++ b/src/main/java/com/drtshock/playervaults/vaultmanagement/CachedVaultsMap.java
@@ -1,0 +1,16 @@
+package com.drtshock.playervaults.vaultmanagement;
+
+import java.util.HashMap;
+
+import org.bukkit.inventory.Inventory;
+
+@SuppressWarnings("serial")
+public class CachedVaultsMap extends HashMap<Integer, Inventory> {
+    public void setCachedVault(int id, Inventory inventory){
+        this.put(id, inventory);
+    }
+    
+    public Inventory getCachedVault(int id){
+        return this.containsKey(id) ? this.get(id) : null;
+    }
+}


### PR DESCRIPTION
Only writes vaults to file on server shutdown or player quit, rather
than every inventory close event. Also caches vault inventory objects for open events, and fixes offline vault viewing due to spoofed UUID returns on main thread getOfflinePlayer() calls.

https://twitter.com/dev_vaquxine/status/602948208952619008