### PR TITLE
Remove redundant "start" method

### DIFF
--- a/src/main/java/com/drtshock/playervaults/PlayerVaults.java
+++ b/src/main/java/com/drtshock/playervaults/PlayerVaults.java
@@ -78,7 +78,6 @@ public class PlayerVaults extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        long start = System.currentTimeMillis();
         instance = this;
         loadConfig();
         DEBUG = getConfig().getBoolean("debug", false);


### PR DESCRIPTION
This method is not used in any classes nor is it useful in anyway, so why not remove it.