### PR TITLE
Update plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: PlayerVaults
 main: com.drtshock.playervaults.PlayerVaults
 authors: [drtshock, kashike]
+ # Note to developers: This next line should not change, or the versioning system will break.
 version: ${project.version}-b${build.number}
 website: http://dev.bukkit.org/server-mods/PlayerVaults
 softdepend: [Vault]


### PR DESCRIPTION
This makes a friendly note to authors who want to write changes to the plugin.yml, and tells them not to modify certain fields or the automated versioning system will break.