### PR TITLE
Fix a small typo

### DIFF
--- a/src/main/java/com/drtshock/playervaults/translations/Language.java
+++ b/src/main/java/com/drtshock/playervaults/translations/Language.java
@@ -3,7 +3,7 @@ package com.drtshock.playervaults.translations;
 public enum Language {
     ENGLISH("english"),
     BULGARIAN("bulgarian"),
-    DUTH("dutch");
+    DUTCH("dutch");
 
     private String friendlyName;
 


### PR DESCRIPTION
It's Dutch, not Duth :stuck_out_tongue:
I hope this doesn't conflict with anything else, but it shouldn't