### PR TITLE
Add blocking items by display name

### DIFF
--- a/src/main/java/com/drtshock/playervaults/PlayerVaults.java
+++ b/src/main/java/com/drtshock/playervaults/PlayerVaults.java
@@ -80,6 +80,7 @@ public class PlayerVaults extends JavaPlugin {
     // VaultViewInfo - Inventory
     private final HashMap<String, Inventory> openInventories = new HashMap<>();
     private final Set<Material> blockedMats = new HashSet<>();
+    private final Set<String> blockedNames = new HashSet<>();
     private boolean useVault;
     private YamlConfiguration signs;
     private File signsFile;
@@ -345,6 +346,17 @@ public class PlayerVaults extends JavaPlugin {
             }
         }
 
+        // Clear just in case this is a reload.
+        blockedNames.clear();
+        if (getConf().getItemBlocking().isEnabled()) {
+            for (String s : getConf().getItemBlocking().getNames()) {
+                if (s != null && !s.isEmpty()) {
+                    blockedNames.add(s);
+                    getLogger().log(Level.INFO, "Added {0} to list of blocked names.", s);
+                }
+            }
+        }
+
         File lang = new File(this.getDataFolder(), "lang");
         if (lang.exists()) {
             this.getLogger().warning("There is no clean way for us to migrate your old lang data.");
@@ -493,6 +505,9 @@ public class PlayerVaults extends JavaPlugin {
 
     public boolean isBlockedMaterial(Material mat) {
         return blockedMats.contains(mat);
+    }
+    public boolean isBlockedName(String name) {
+        return blockedNames.contains(name);
     }
 
     /**

--- a/src/main/java/com/drtshock/playervaults/config/file/Config.java
+++ b/src/main/java/com/drtshock/playervaults/config/file/Config.java
@@ -48,6 +48,21 @@ public class Config {
             }
             return Collections.unmodifiableList(list);
         }
+
+        @Comment("Exact item names for blocked items, only effective if the feature is enabled.\n" +
+                " Useful for blocking custom items based on item name.")
+        private List<String> names = new ArrayList<String>() {
+            {
+                this.add("Named item to be blocked");
+            }
+        };
+
+        public List<String> getNames() {
+            if (this.names == null) {
+                this.names = new ArrayList<>();
+            }
+            return Collections.unmodifiableList(names);
+        }
     }
 
     public class Economy {

--- a/src/main/java/com/drtshock/playervaults/config/file/Translation.java
+++ b/src/main/java/com/drtshock/playervaults/config/file/Translation.java
@@ -218,6 +218,7 @@ public class Translation {
         private TL locked = TL.of("<error>Vaults are currently locked while conversion occurs. Please try again in a moment!");
         private TL help = TL.of("/pv <number>");
         private TL blockedItem = TL.of("<gold>{item}</gold> <error>is blocked from vaults.");
+        private TL blockedItemName = TL.of("<gold>{name}</gold> <error>is blocked from vaults.");
         private TL signsDisabled = TL.of("<error>Vault signs are currently disabled.");
         private TL blockedBadItem = TL.of("<error>This item is not allowed in a vault.");
     }
@@ -348,6 +349,10 @@ public class Translation {
 
     public @NonNull TL blockedItem() {
         return this.translations.blockedItem;
+    }
+
+    public @NonNull TL blockedItemName() {
+        return this.translations.blockedItemName;
     }
 
     public @NonNull TL signsDisabled() {

--- a/src/main/java/com/drtshock/playervaults/listeners/Listeners.java
+++ b/src/main/java/com/drtshock/playervaults/listeners/Listeners.java
@@ -132,10 +132,17 @@ public class Listeners implements Listener {
                         if (item == null) {
                             continue;
                         }
-                        if (!player.hasPermission("playervaults.bypassblockeditems") && PlayerVaults.getInstance().isBlockedMaterial(item.getType())) {
-                            event.setCancelled(true);
-                            this.plugin.getTL().blockedItem().title().with("item", item.getType().name()).send(player);
-                            return;
+                        if (!player.hasPermission("playervaults.bypassblockeditems")) {
+                            if (PlayerVaults.getInstance().isBlockedMaterial(item.getType())) {
+                                event.setCancelled(true);
+                                this.plugin.getTL().blockedItem().title().with("item", item.getType().name()).send(player);
+                                return;
+                            }
+                            else if (PlayerVaults.getInstance().isBlockedName(item.getItemMeta().getDisplayName())) {
+                                event.setCancelled(true);
+                                this.plugin.getTL().blockedItemName().title().with("name", item.getItemMeta().getDisplayName()).send(player);
+                                return;
+                            }
                         }
                     }
                 }
@@ -160,10 +167,17 @@ public class Listeners implements Listener {
                 String title = this.plugin.getVaultTitle(String.valueOf(num));
                 if ((inventoryTitle != null && inventoryTitle.equalsIgnoreCase(title)) && event.getNewItems() != null) {
                     for (ItemStack item : event.getNewItems().values()) {
-                        if (!player.hasPermission("playervaults.bypassblockeditems") && PlayerVaults.getInstance().isBlockedMaterial(item.getType())) {
-                            event.setCancelled(true);
-                            this.plugin.getTL().blockedItem().title().with("item", item.getType().name()).send(player);
-                            return;
+                        if (!player.hasPermission("playervaults.bypassblockeditems")) {
+                            if (PlayerVaults.getInstance().isBlockedMaterial(item.getType())) {
+                                event.setCancelled(true);
+                                this.plugin.getTL().blockedItem().title().with("item", item.getType().name()).send(player);
+                                return;
+                            }
+                            else if (PlayerVaults.getInstance().isBlockedName(item.getItemMeta().getDisplayName())) {
+                                event.setCancelled(true);
+                                this.plugin.getTL().blockedItemName().title().with("name", item.getItemMeta().getDisplayName()).send(player);
+                                return;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This adds functionality to allow blocking items by display name. It checks against the exact display name and doesn't take colours into consideration, so names need to include colours. Not sure if you would prefer it to work a little different, it's a fairly simple change. I tried to make minimal changes, hopefully this is ok.

An example of a working config:
```
itemBlocking {
    enabled=true

    # Material list for blocked items (does not support ID's), only effective if the feature is enabled.
    # If you don't know material names: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html
    list=[]

    # Exact item names for blocked items, only effective if the feature is enabled.
    # Useful for blocking custom items based on item name.
    names=[
        "§eSmall Backpack",
        "§eMedium Backpack",
        "§eLarge Backpack"
    ]

    ....
```

![image](https://user-images.githubusercontent.com/1924905/165720535-51ba1c45-49c6-4ee5-b1bc-3956dea98470.png)
