### PR TITLE
Add PlayerVaultsBlacklistedItemEvent

### DIFF
--- a/src/main/java/com/drtshock/playervaults/events/PlayerVaultsBlacklistedItemEvent.java
+++ b/src/main/java/com/drtshock/playervaults/events/PlayerVaultsBlacklistedItemEvent.java
@@ -29,11 +29,13 @@ public class PlayerVaultsBlacklistedItemEvent extends Event implements Cancellab
     private static final HandlerList handlers = new HandlerList();
     private boolean isCancelled;
     private final ItemStack item;
+    private final int vaultNumber;
     private final Player player;
 
-    public PlayerVaultsBlacklistedItemEvent(Player player, ItemStack item) {
+    public PlayerVaultsBlacklistedItemEvent(Player player, ItemStack item, int vaultNumber) {
         this.player = player;
         this.item = item;
+        this.vaultNumber = vaultNumber;
         this.isCancelled = false;
     }
 
@@ -43,6 +45,10 @@ public class PlayerVaultsBlacklistedItemEvent extends Event implements Cancellab
 
     public ItemStack getItem() {
         return item;
+    }
+
+    public int getVaultNumber() {
+        return vaultNumber;
     }
 
     @Override

--- a/src/main/java/com/drtshock/playervaults/events/PlayerVaultsBlacklistedItemEvent.java
+++ b/src/main/java/com/drtshock/playervaults/events/PlayerVaultsBlacklistedItemEvent.java
@@ -1,3 +1,21 @@
+/*
+ * PlayerVaultsX
+ * Copyright (C) 2013 Trent Hensler
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.drtshock.playervaults.events;
 
 import org.bukkit.entity.Player;

--- a/src/main/java/com/drtshock/playervaults/events/PlayerVaultsBlacklistedItemEvent.java
+++ b/src/main/java/com/drtshock/playervaults/events/PlayerVaultsBlacklistedItemEvent.java
@@ -1,0 +1,48 @@
+package com.drtshock.playervaults.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+public class PlayerVaultsBlacklistedItemEvent extends Event implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+    private boolean isCancelled;
+    private final ItemStack item;
+    private final Player player;
+
+    public PlayerVaultsBlacklistedItemEvent(Player player, ItemStack item) {
+        this.player = player;
+        this.item = item;
+        this.isCancelled = false;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public ItemStack getItem() {
+        return item;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return isCancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.isCancelled = cancelled;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/com/drtshock/playervaults/listeners/Listeners.java
+++ b/src/main/java/com/drtshock/playervaults/listeners/Listeners.java
@@ -19,6 +19,7 @@
 package com.drtshock.playervaults.listeners;
 
 import com.drtshock.playervaults.PlayerVaults;
+import com.drtshock.playervaults.events.PlayerVaultsBlacklistedItemEvent;
 import com.drtshock.playervaults.vaultmanagement.VaultManager;
 import com.drtshock.playervaults.vaultmanagement.VaultViewInfo;
 import org.bukkit.Bukkit;
@@ -136,20 +137,24 @@ public class Listeners implements Listener {
                             continue;
                         }
                         if (!player.hasPermission("playervaults.bypassblockeditems")) {
-                            if (PlayerVaults.getInstance().isBlockWithModelData() && item.hasItemMeta() && item.getItemMeta().hasCustomModelData()) {
-                                event.setCancelled(true);
-                                this.plugin.getTL().blockedItemWithModelData().title().send(player);
-                                return;
-                            }
-                            if (PlayerVaults.getInstance().isBlockWithoutModelData() && (!item.hasItemMeta() || !item.getItemMeta().hasCustomModelData())) {
-                                event.setCancelled(true);
-                                this.plugin.getTL().blockedItemWithoutModelData().title().send(player);
-                                return;
-                            }
-                            if (PlayerVaults.getInstance().isBlockedMaterial(item.getType())) {
-                                event.setCancelled(true);
-                                this.plugin.getTL().blockedItem().title().with("item", item.getType().name()).send(player);
-                                return;
+                            PlayerVaultsBlacklistedItemEvent playerVaultsBlacklistedItemEvent = new PlayerVaultsBlacklistedItemEvent(player, item);
+                            this.plugin.getServer().getPluginManager().callEvent(playerVaultsBlacklistedItemEvent);
+                            if (!playerVaultsBlacklistedItemEvent.isCancelled()) {
+                                if (PlayerVaults.getInstance().isBlockWithModelData() && item.hasItemMeta() && item.getItemMeta().hasCustomModelData()) {
+                                    event.setCancelled(true);
+                                    this.plugin.getTL().blockedItemWithModelData().title().send(player);
+                                    return;
+                                }
+                                if (PlayerVaults.getInstance().isBlockWithoutModelData() && (!item.hasItemMeta() || !item.getItemMeta().hasCustomModelData())) {
+                                    event.setCancelled(true);
+                                    this.plugin.getTL().blockedItemWithoutModelData().title().send(player);
+                                    return;
+                                }
+                                if (PlayerVaults.getInstance().isBlockedMaterial(item.getType())) {
+                                    event.setCancelled(true);
+                                    this.plugin.getTL().blockedItem().title().with("item", item.getType().name()).send(player);
+                                    return;
+                                }
                             }
                         }
                     }

--- a/src/main/java/com/drtshock/playervaults/listeners/Listeners.java
+++ b/src/main/java/com/drtshock/playervaults/listeners/Listeners.java
@@ -137,23 +137,27 @@ public class Listeners implements Listener {
                             continue;
                         }
                         if (!player.hasPermission("playervaults.bypassblockeditems")) {
-                            PlayerVaultsBlacklistedItemEvent playerVaultsBlacklistedItemEvent = new PlayerVaultsBlacklistedItemEvent(player, item);
-                            this.plugin.getServer().getPluginManager().callEvent(playerVaultsBlacklistedItemEvent);
-                            if (!playerVaultsBlacklistedItemEvent.isCancelled()) {
-                                if (PlayerVaults.getInstance().isBlockWithModelData() && item.hasItemMeta() && item.getItemMeta().hasCustomModelData()) {
-                                    event.setCancelled(true);
-                                    this.plugin.getTL().blockedItemWithModelData().title().send(player);
-                                    return;
-                                }
-                                if (PlayerVaults.getInstance().isBlockWithoutModelData() && (!item.hasItemMeta() || !item.getItemMeta().hasCustomModelData())) {
-                                    event.setCancelled(true);
-                                    this.plugin.getTL().blockedItemWithoutModelData().title().send(player);
-                                    return;
-                                }
-                                if (PlayerVaults.getInstance().isBlockedMaterial(item.getType())) {
-                                    event.setCancelled(true);
-                                    this.plugin.getTL().blockedItem().title().with("item", item.getType().name()).send(player);
-                                    return;
+                            InventoryHolder holder = event.getInventory().getHolder();
+                            if (holder instanceof VaultHolder vaultHolder) {
+                                int vaultNumber = vaultHolder.getVaultNumber();
+                                PlayerVaultsBlacklistedItemEvent playerVaultsBlacklistedItemEvent = new PlayerVaultsBlacklistedItemEvent(player, item, vaultNumber);
+                                this.plugin.getServer().getPluginManager().callEvent(playerVaultsBlacklistedItemEvent);
+                                if (!playerVaultsBlacklistedItemEvent.isCancelled()) {
+                                    if (PlayerVaults.getInstance().isBlockWithModelData() && item.hasItemMeta() && item.getItemMeta().hasCustomModelData()) {
+                                        event.setCancelled(true);
+                                        this.plugin.getTL().blockedItemWithModelData().title().send(player);
+                                        return;
+                                    }
+                                    if (PlayerVaults.getInstance().isBlockWithoutModelData() && (!item.hasItemMeta() || !item.getItemMeta().hasCustomModelData())) {
+                                        event.setCancelled(true);
+                                        this.plugin.getTL().blockedItemWithoutModelData().title().send(player);
+                                        return;
+                                    }
+                                    if (PlayerVaults.getInstance().isBlockedMaterial(item.getType())) {
+                                        event.setCancelled(true);
+                                        this.plugin.getTL().blockedItem().title().with("item", item.getType().name()).send(player);
+                                        return;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
This event would be fired when a blacklisted item is added to inventory, If the event is cancelled, then it allows the item to be stored in inventory, which is helpful for addons.

```java
    @EventHandler
    public void onBlacklistedItem(PlayerVaultsBlacklistedItemEvent event) {
        ItemStack item = event.getItem();

        // Example blacklist check: block DIAMOND_SWORD for example
        if (item.getType() == Material.DIAMOND_SWORD) {
            event.setCancelled(true);  // Automatically cancel the event for blacklisted items and store in database
        }
    }
 ```